### PR TITLE
Split up GraphQL schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+internal/pkg/schema/bindata.go

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ If using Go 1.13, the `go` command defaults to downloading modules from the publ
 go env -w GOPRIVATE=github.com/sylabs
 ```
 
+Install `go-bindata` to help generate the GraphQL schema later:
+
+```sh
+go get -u github.com/jteeuwen/go-bindata/...
+```
+
+In order for go to execute this binary the path in `go env GOPATH` needs to be included in your `PATH`.
+
 To run the server, you'll need a MongoDB endpoint to point it to. If you don't have one already, you can start one with Docker easy enough:
 
 ```sh
@@ -25,7 +33,7 @@ docker run -d -p 27017:27017 mongo
 Finally, start the server:
 
 ```sh
-$ go run ./cmd/server/
+$ go generate ./... && go run ./cmd/server/
 INFO[0000] starting                                      name="Compute Server" org=Sylabs
 INFO[0000] connecting to database
 INFO[0000] database ready                                took=7.375268ms

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -4,6 +4,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 
@@ -41,7 +42,12 @@ func New(ctx context.Context, c Config) (s Server, err error) {
 	}
 
 	// Initialize GraphQL.
-	schema, err := graphql.ParseSchema(schema.String(), resolver.New(c.Persist))
+	sch, err := schema.String()
+	if err != nil {
+		return Server{}, fmt.Errorf("unable to init GraphQL schema: %w", err)
+	}
+
+	schema, err := graphql.ParseSchema(sch, resolver.New(c.Persist))
 	if err != nil {
 		return Server{}, err
 	}

--- a/internal/pkg/schema/job.graphql
+++ b/internal/pkg/schema/job.graphql
@@ -1,0 +1,4 @@
+type Job {
+  id: ID!
+  name: String!
+}

--- a/internal/pkg/schema/mutation.graphql
+++ b/internal/pkg/schema/mutation.graphql
@@ -1,0 +1,4 @@
+type Mutation {
+  createJob(name: String!): Job
+  deleteJob(id: ID!): Job
+}

--- a/internal/pkg/schema/query.graphql
+++ b/internal/pkg/schema/query.graphql
@@ -1,0 +1,3 @@
+type Query {
+  job(id: ID!): Job
+}

--- a/internal/pkg/schema/schema.go
+++ b/internal/pkg/schema/schema.go
@@ -1,28 +1,34 @@
-// Copyright (c) 2020, Sylabs, Inc. All rights reserved.
-
+// Use `go generate` to pack all *.graphql files under this directory (and sub-directories) into
+// a binary format.
+//
+//go:generate go-bindata -ignore=\.go -pkg=schema -o=bindata.go ./...
 package schema
 
-// String returns the GraphQL schema.
-func String() string {
-	// TODO: splint into .graphql files and go-gen into this file.
-	return `
-schema {
-  query: Query
-  mutation: Mutation
-}
+import (
+	"bytes"
+	"fmt"
+)
 
-type Query {
-  job(id: ID!): Job
-}
+// String reads the .graphql schema files from the generated _bindata.go file, concatenating the
+// files together into one string.
+//
+// If this method complains about not finding functions AssetNames() or MustAsset(),
+// run `go generate` against this package to generate the functions.
+func String() (string, error) {
+	buf := bytes.Buffer{}
+	for _, name := range AssetNames() {
+		b, err := Asset(name)
+		if err != nil {
+			return "", fmt.Errorf("asset: Asset(%q): %w", name, err)
+		}
 
-type Mutation {
-  createJob(name: String!): Job
-  deleteJob(id: ID!): Job
-}
+		buf.Write(b)
 
-type Job {
-  id: ID!
-  name: String!
-}
-	`
+		// Add a newline if the file does not end in a newline.
+		if len(b) > 0 && b[len(b)-1] != '\n' {
+			buf.WriteByte('\n')
+		}
+	}
+
+	return buf.String(), nil
 }

--- a/internal/pkg/schema/schema.graphql
+++ b/internal/pkg/schema/schema.graphql
@@ -1,0 +1,4 @@
+schema {
+  query: Query
+  mutation: Mutation
+}


### PR DESCRIPTION
Splits the GraphQL schema into multiple *.graphql files and assembles
them with `go generate` before building. Updates README.md and creates a
.gitignore to ignore intermediate data generated.

Signed-off-by: Ian Kaneshiro <iankane@umich.edu>