### PR TITLE
Finish WorkflowEdge Resolver

### DIFF
--- a/internal/pkg/resolver/workflow_connection_resolver.go
+++ b/internal/pkg/resolver/workflow_connection_resolver.go
@@ -6,16 +6,17 @@ import "github.com/sylabs/compute-service/internal/pkg/model"
 
 // WorkflowEdgeResolver resolves a workflow edge.
 type WorkflowEdgeResolver struct {
+	w model.Workflow
 }
 
 // Cursor resolves a cursor for use in pagination.
 func (r *WorkflowEdgeResolver) Cursor() string {
-	return "" // TODO
+	return r.w.ID
 }
 
 // Node resolves the item at the end of the edge.
 func (r *WorkflowEdgeResolver) Node() *WorkflowResolver {
-	return nil // TODO
+	return &WorkflowResolver{r.w}
 }
 
 // WorkflowConnectionResolver resolves a workflow connection.
@@ -25,14 +26,18 @@ type WorkflowConnectionResolver struct {
 
 // Edges resolves a list of edges.
 func (r *WorkflowConnectionResolver) Edges() *[]*WorkflowEdgeResolver {
-	return nil // TODO
+	wer := []*WorkflowEdgeResolver{}
+	for _, w := range r.p.Workflows {
+		wer = append(wer, &WorkflowEdgeResolver{w})
+	}
+	return &wer
 }
 
 // Nodes resolves a list of nodes.
 func (r *WorkflowConnectionResolver) Nodes() *[]*WorkflowResolver {
 	wr := []*WorkflowResolver{}
 	for _, w := range r.p.Workflows {
-		wr = append(wr, &WorkflowResolver{&w})
+		wr = append(wr, &WorkflowResolver{w})
 	}
 	return &wr
 }

--- a/internal/pkg/resolver/workflow_mutation.go
+++ b/internal/pkg/resolver/workflow_mutation.go
@@ -19,7 +19,7 @@ func (r Resolver) CreateWorkflow(ctx context.Context, args struct {
 	if err != nil {
 		return nil, err
 	}
-	return &WorkflowResolver{&j}, nil
+	return &WorkflowResolver{j}, nil
 }
 
 // DeleteWorkflow deletes a workflow.
@@ -30,5 +30,5 @@ func (r Resolver) DeleteWorkflow(ctx context.Context, args struct {
 	if err != nil {
 		return nil, err
 	}
-	return &WorkflowResolver{&j}, nil
+	return &WorkflowResolver{j}, nil
 }

--- a/internal/pkg/resolver/workflow_query.go
+++ b/internal/pkg/resolver/workflow_query.go
@@ -14,5 +14,5 @@ func (r Resolver) Workflow(ctx context.Context, args struct {
 	if err != nil {
 		return nil, err
 	}
-	return &WorkflowResolver{&j}, nil
+	return &WorkflowResolver{j}, nil
 }

--- a/internal/pkg/resolver/workflow_resolver.go
+++ b/internal/pkg/resolver/workflow_resolver.go
@@ -19,7 +19,7 @@ type WorkflowPersister interface {
 
 // WorkflowResolver resolves a workflow.
 type WorkflowResolver struct {
-	w *model.Workflow
+	w model.Workflow
 }
 
 // ID resolves the workflow ID.


### PR DESCRIPTION
Fill in `WorkflowEdge` resolver. Sample query to test:

```
{
  viewer {
    id
    login
    workflows {
      edges {
        cursor
        node {
          id
          name
        }
      }
    }
  }
}
```

Which should return something like:

```
{
  "data": {
    "viewer": {
      "id": "507f1f77bcf86cd799439011",
      "login": "jimbob",
      "workflows": {
        "edges": [
          {
            "cursor": "5e21f4a00b1e8041c8807f4a",
            "node": {
              "id": "5e21f4a00b1e8041c8807f4a",
              "name": "blah"
            }
          },
          {
            "cursor": "5e21f4c70b1e8041c8807f4b",
            "node": {
              "id": "5e21f4c70b1e8041c8807f4b",
              "name": "snah"
            }
          }
        ]
      }
    }
  }
}
```