### PR TITLE
Validate Request Tokens

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -36,6 +36,7 @@ var (
 	startupTime        = flag.Duration("startup-time", time.Minute, "Amount of time to wait for dependent services to become ready on startup")
 	natsURIs           = flag.String("nats-uris", nats.DefaultURL, "Comma-separated list of NATS server URIs")
 	oauth2IssuerURI    = flag.String("oauth2-issuer-uri", "https://dev-930666.okta.com/oauth2/default", "URI of OAuth 2.0 issuer")
+	oauth2Audience     = flag.String("oauth2-audience", "api://default", "OAuth 2.0 audience expected in tokens")
 )
 
 // signalHandler catches SIGINT/SIGTERM to perform an orderly shutdown.
@@ -138,6 +139,7 @@ func main() {
 		Persist:            conn,
 		NATSConn:           nc,
 		OAuth2IssuerURI:    *oauth2IssuerURI,
+		OAuth2Audience:     *oauth2Audience,
 	}
 	s, err := server.New(ctx, c)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.13
 
 require (
 	github.com/DataDog/zstd v1.4.4 // indirect
+	github.com/auth0/go-jwt-middleware v0.0.0-20190805220309-36081240882b
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/friendsofgo/graphiql v0.2.2
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/auth0/go-jwt-middleware v0.0.0-20190805220309-36081240882b h1:CvoEHGmxWl5kONC5icxwqV899dkf4VjOScbxLpllEnw=
+github.com/auth0/go-jwt-middleware v0.0.0-20190805220309-36081240882b/go.mod h1:LWMyo4iOLWXHGdBki7NIht1kHru/0wM179h+d3g8ATM=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -13,6 +15,8 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/friendsofgo/graphiql v0.2.2 h1:ccnuxpjgIkB+Lr9YB2ZouiZm7wvciSfqwpa9ugWzmn0=
 github.com/friendsofgo/graphiql v0.2.2/go.mod h1:8Y2kZ36AoTGWs78+VRpvATyt3LJBx0SZXmay80ZTRWo=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -74,6 +78,7 @@ github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.3.0 h1:miYCvYqFXtl/J9FIy8eNpBfYthAEFg+Ys0XyUVEcDsc=
 github.com/prometheus/client_golang v1.3.0/go.mod h1:hJaj2vgQTGQmVCsAACORcieXFeDPbaTKGT+JTgUa3og=
+github.com/prometheus/client_golang v1.4.1 h1:FFSuS004yOQEtDdTq+TAOLP5xUq63KqAFYyOi8zA+Y8=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.1.0 h1:ElTg5tNp4DqfV7UQjDqv2+RJlNzsDtvNAWccbItceIE=

--- a/internal/app/server/router.go
+++ b/internal/app/server/router.go
@@ -32,6 +32,9 @@ func (s *Server) NewRouter(c Config) (http.Handler, error) {
 			return nil, err
 		}
 
+		// Add JWT middleware.
+		h = s.tokenHandler(c, h)
+
 		// Instrument with Prometheus.
 		h = promhttp.InstrumentHandlerInFlight(httpRequestsInFlight,
 			promhttp.InstrumentHandlerCounter(httpRequestsTotal,

--- a/internal/app/server/router_test.go
+++ b/internal/app/server/router_test.go
@@ -22,10 +22,10 @@ var testRouteConfigs = []struct {
 	path         string
 	expectedCode int
 }{
-	{"GetVersion", http.MethodGet, "/version", http.StatusOK},
-	{"GetMetrics", http.MethodGet, "/metrics", http.StatusOK},
-	{"PostGraphQL", http.MethodPost, "/graphql", http.StatusBadRequest},
-	{"GetGraphiQL", http.MethodGet, "/graphiql", http.StatusOK},
+	{"GetVersion", http.MethodGet, "/version", http.StatusUnauthorized},
+	{"GetMetrics", http.MethodGet, "/metrics", http.StatusUnauthorized},
+	{"PostGraphQL", http.MethodPost, "/graphql", http.StatusUnauthorized},
+	{"GetGraphiQL", http.MethodGet, "/graphiql", http.StatusUnauthorized},
 }
 
 func TestRouteConfigs(t *testing.T) {

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -28,6 +28,7 @@ type Config struct {
 	Persist            *mongodb.Connection
 	NATSConn           *nats.Conn
 	OAuth2IssuerURI    string
+	OAuth2Audience     string
 }
 
 // Server contains the state of the server.

--- a/internal/app/server/token.go
+++ b/internal/app/server/token.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2020, Sylabs, Inc. All rights reserved.
+
+package server
+
+import (
+	"errors"
+	"net/http"
+
+	jwtmiddleware "github.com/auth0/go-jwt-middleware"
+	"github.com/dgrijalva/jwt-go"
+	"github.com/sirupsen/logrus"
+)
+
+// tokenHandler parses and validates a JSON Web Token (JWT) in the authorization bearer of the
+// request. If a valid token is found, it adds it to the request context for use by next.
+func (s *Server) tokenHandler(c Config, next http.Handler) http.Handler {
+	jwt := jwtmiddleware.New(jwtmiddleware.Options{
+		ValidationKeyGetter: func(t *jwt.Token) (interface{}, error) {
+			// Audience and issuer must match our configuration.
+			if !t.Claims.(jwt.MapClaims).VerifyAudience(c.OAuth2Audience, false) {
+				return nil, errors.New("invalid audience claim")
+			}
+			if !t.Claims.(jwt.MapClaims).VerifyIssuer(c.OAuth2IssuerURI, false) {
+				return nil, errors.New("invalid issuer claim")
+			}
+
+			// Algorithm and key ID must match a key in the server state.
+			alg, ok := t.Header["alg"]
+			if !ok {
+				return nil, errors.New("algorithm not present")
+			}
+			kid, ok := t.Header["kid"]
+			if !ok {
+				return nil, errors.New("key ID not present")
+			}
+			for _, k := range s.authKeys.Keys {
+				if alg == k.Algorithm && kid == k.KeyID {
+					return k.Key, nil
+				}
+			}
+			return nil, errors.New("key not found")
+		},
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err string) {
+			logrus.WithField("error", err).Warn("failed to validate JWT")
+			http.Error(w, err, http.StatusUnauthorized)
+		},
+	})
+	return jwt.Handler(next)
+}


### PR DESCRIPTION
Extract and validate JWT for all HTTP requests. Add `-oauth2-audience` flag which verifies the `aud` claim.

Note that this enables authentication on **all** HTTP endpoints. We will need more fine-grained checks than this, which will be introduced in a future PR.