### PR TITLE
Viewer User Info from Token

### DIFF
--- a/internal/pkg/core/core.go
+++ b/internal/pkg/core/core.go
@@ -4,6 +4,9 @@ package core
 
 import (
 	"context"
+	"errors"
+
+	"github.com/sylabs/compute-service/internal/pkg/token"
 )
 
 // Persister is the interface by which all data is persisted.
@@ -37,10 +40,15 @@ func New(p Persister, f IOFetcher, s Scheduler) (*Core, error) {
 
 // Viewer returns the user associated with ctx.
 func (c *Core) Viewer(ctx context.Context) (User, error) {
-	// TODO: authorization
+	t, ok := token.FromContext(ctx)
+	if !ok {
+		return User{}, errors.New("viewer not logged in")
+	}
+	tc := t.Claims()
+
 	u := User{
-		ID:    "507f1f77bcf86cd799439011",
-		Login: "jimbob",
+		ID:    tc.UserID,
+		Login: tc.Subject,
 	}
 	u.setCore(c)
 	return u, nil

--- a/internal/pkg/resolver/viewer_test.go
+++ b/internal/pkg/resolver/viewer_test.go
@@ -6,10 +6,23 @@ import (
 	"context"
 	"testing"
 
+	"github.com/dgrijalva/jwt-go"
 	"github.com/sylabs/compute-service/internal/pkg/core"
+	"github.com/sylabs/compute-service/internal/pkg/token"
 )
 
 func TestViewer(t *testing.T) {
+	// User token to pass in context.
+	tok := token.Token{
+		Token: jwt.NewWithClaims(jwt.SigningMethodNone, &token.Claims{
+			StandardClaims: jwt.StandardClaims{
+				Subject: "jimbob",
+			},
+			UserID: "507f1f77bcf86cd799439011",
+		}),
+	}
+	ctx := token.NewContext(context.Background(), &tok)
+
 	sc := "startCursor"
 	ec := "endCursor"
 	wp := core.WorkflowsPage{
@@ -88,7 +101,7 @@ func TestViewer(t *testing.T) {
 			  }
 			}`
 
-			res := s.Exec(context.Background(), q, "", tt.args)
+			res := s.Exec(ctx, q, "", tt.args)
 
 			if err := verifyGoldenJSON(t.Name(), res); err != nil {
 				t.Fatal(err)

--- a/internal/pkg/token/claims.go
+++ b/internal/pkg/token/claims.go
@@ -7,6 +7,7 @@ import "github.com/dgrijalva/jwt-go"
 // Claims type.
 type Claims struct {
 	jwt.StandardClaims
+	UserID string `json:"uid,omitempty"`
 }
 
 // VerifyAudience compares the "aud" claim (if present) against cmp.

--- a/internal/pkg/token/main_test.go
+++ b/internal/pkg/token/main_test.go
@@ -34,7 +34,7 @@ func makeToken(c *Claims) string {
 func TestMain(m *testing.M) {
 	// Claims for testing.
 	testClaims = &Claims{
-		jwt.StandardClaims{
+		StandardClaims: jwt.StandardClaims{
 			Id:        "id",
 			Subject:   "subject",
 			Audience:  "api://default",
@@ -50,21 +50,21 @@ func TestMain(m *testing.M) {
 
 	// Bad audience value.
 	testTokenInvalidAudience = makeToken(&Claims{
-		jwt.StandardClaims{
+		StandardClaims: jwt.StandardClaims{
 			Audience: "bad",
 		},
 	})
 
 	// Bad issuer value.
 	testTokenInvalidIssuer = makeToken(&Claims{
-		jwt.StandardClaims{
+		StandardClaims: jwt.StandardClaims{
 			Issuer: "bad",
 		},
 	})
 
 	// Expired.
 	testTokenExpired = makeToken(&Claims{
-		jwt.StandardClaims{
+		StandardClaims: jwt.StandardClaims{
 			ExpiresAt: 1000000000,
 		},
 	})


### PR DESCRIPTION
Wire up `viewer` query to real data from JWT. Can test with GraphiQL:

```
query{
  viewer{
    id
    login
  }
}
```

```
{
  "data": {
    "viewer": {
      "id": "00u24jgyrubX4CiWY4x6",
      "login": "adam@sylabs.io"
    }
  }
}
```