### PR TITLE
Redis URI Support

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -36,8 +36,8 @@ var (
 	corsDebug          = flag.Bool("cors-debug", false, "Enable CORS debugging")
 	mongoURI           = flag.String("mongo-uri", "mongodb://localhost", "URI of MongoDB database")
 	startupTime        = flag.Duration("startup-time", time.Minute, "Amount of time to wait for dependent services to become ready on startup")
-	natsURIs           = flag.String("nats-uris", nats.DefaultURL, "Comma-separated list of NATS server URIs")
-	redisAddr          = flag.String("redis-addr", "localhost:6379", "Address of Redis")
+	natsURIs           = flag.String("nats-uris", "nats://localhost", "Comma-separated list of NATS server URIs")
+	redisURI           = flag.String("redis-uri", "redis://localhost", "URI of Redis")
 	oauth2IssuerURI    = flag.String("oauth2-issuer-uri", "https://dev-930666.okta.com/oauth2/default", "URI of OAuth 2.0 issuer")
 	oauth2Audience     = flag.String("oauth2-audience", "api://default", "OAuth 2.0 audience expected in tokens")
 )
@@ -107,7 +107,7 @@ func connectNATS(ctx context.Context) (nc *nats.Conn, err error) {
 
 // connectRedis attempts to connect to redis.
 func connectRedis() (*rediskv.Connection, error) {
-	rc, err := rediskv.NewConnection(*redisAddr)
+	rc, err := rediskv.NewConnection(*redisURI)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/rediskv/redis_test.go
+++ b/internal/pkg/rediskv/redis_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	redisURI = flag.String("redis-uri", "localhost:6379", "URI of Redis")
+	redisURI = flag.String("redis-uri", "redis://localhost", "URI of Redis")
 
 	testConnection *Connection
 )


### PR DESCRIPTION
Add support for full Redis URI ([ref](https://www.iana.org/assignments/uri-schemes/prov/redis)) to allow user to specify options. Ping Redis in `NewConnection()` to ensure connection is valid, and log client ID to assist in troubleshooting.