### PR TITLE
Replace Flag with Pflag

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -4,15 +4,14 @@ package main
 
 import (
 	"context"
-	"flag"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
 	"github.com/nats-io/nats.go"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
 	"github.com/sylabs/compute-service/internal/app/iomanager"
 	"github.com/sylabs/compute-service/internal/app/server"
 	"github.com/sylabs/compute-service/internal/pkg/mongodb"
@@ -27,18 +26,6 @@ const (
 )
 
 var version = "unknown"
-
-var (
-	httpAddr           = flag.String("http-addr", ":8080", "Address to bind HTTP")
-	corsAllowedOrigins = flag.String("cors-allowed-origins", "*", "Comma-separated list of CORS allowed origins")
-	corsDebug          = flag.Bool("cors-debug", false, "Enable CORS debugging")
-	mongoURI           = flag.String("mongo-uri", "mongodb://localhost", "URI of MongoDB database")
-	startupTime        = flag.Duration("startup-time", time.Minute, "Amount of time to wait for dependent services to become ready on startup")
-	natsURIs           = flag.String("nats-uris", "nats://localhost", "Comma-separated list of NATS server URIs")
-	redisURI           = flag.String("redis-uri", "redis://localhost", "URI of Redis")
-	oauth2IssuerURI    = flag.String("oauth2-issuer-uri", "https://dev-930666.okta.com/oauth2/default", "URI of OAuth 2.0 issuer")
-	oauth2Audience     = flag.String("oauth2-audience", "api://default", "OAuth 2.0 audience expected in tokens")
-)
 
 // signalHandler catches SIGINT/SIGTERM to perform an orderly shutdown.
 func signalHandler(nc *nats.Conn, s server.Server, m iomanager.IOManager) {
@@ -68,7 +55,7 @@ func signalHandler(nc *nats.Conn, s server.Server, m iomanager.IOManager) {
 }
 
 // connectDB attempts to connect to the database.
-func connectDB(ctx context.Context) (conn *mongodb.Connection, err error) {
+func connectDB(ctx context.Context, uri string) (mc *mongodb.Connection, err error) {
 	logrus.Info("connecting to database")
 	defer func(t time.Time) {
 		if err == nil {
@@ -76,11 +63,11 @@ func connectDB(ctx context.Context) (conn *mongodb.Connection, err error) {
 		}
 	}(time.Now())
 
-	return mongodb.NewConnection(ctx, *mongoURI, dbName)
+	return mongodb.NewConnection(ctx, uri, dbName)
 }
 
 // connectNATS attempts to connect to the NATS system.
-func connectNATS(ctx context.Context) (nc *nats.Conn, err error) {
+func connectNATS(ctx context.Context, uris []string) (nc *nats.Conn, err error) {
 	logrus.Print("connecting to messaging system")
 	defer func(t time.Time) {
 		if err == nil {
@@ -99,13 +86,13 @@ func connectNATS(ctx context.Context) (nc *nats.Conn, err error) {
 	}(time.Now())
 
 	o := nats.GetDefaultOptions()
-	o.Servers = strings.Split(*natsURIs, ",")
+	o.Servers = uris
 	return o.Connect()
 }
 
 // connectRedis attempts to connect to redis.
-func connectRedis() (*rediskv.Connection, error) {
-	rc, err := rediskv.NewConnection(*redisURI)
+func connectRedis(uri string) (*rediskv.Connection, error) {
+	rc, err := rediskv.NewConnection(uri)
 	if err != nil {
 		return nil, err
 	}
@@ -113,8 +100,6 @@ func connectRedis() (*rediskv.Connection, error) {
 }
 
 func main() {
-	flag.Parse()
-
 	log := logrus.WithFields(logrus.Fields{
 		"org":  org,
 		"name": name,
@@ -125,25 +110,40 @@ func main() {
 	log.Info("starting")
 	defer log.Info("stopped")
 
+	// Parse command line flags.
+	fs := pflag.CommandLine
+	var (
+		httpAddr           = fs.String("http-addr", ":8080", "Address to bind HTTP")
+		corsAllowedOrigins = fs.StringSlice("cors-allowed-origins", []string{"*"}, "Comma-separated list of CORS allowed origins")
+		corsDebug          = fs.Bool("cors-debug", false, "Enable CORS debugging")
+		mongoURI           = fs.String("mongo-uri", "mongodb://localhost", "URI of MongoDB database")
+		startupTime        = fs.Duration("startup-time", time.Minute, "Amount of time to wait for dependent services to become ready on startup")
+		natsURIs           = fs.StringSlice("nats-uris", []string{"nats://localhost"}, "Comma-separated list of NATS server URIs")
+		redisURI           = fs.String("redis-uri", "redis://localhost", "URI of Redis")
+		oauth2IssuerURI    = fs.String("oauth2-issuer-uri", "https://dev-930666.okta.com/oauth2/default", "URI of OAuth 2.0 issuer")
+		oauth2Audience     = fs.String("oauth2-audience", "api://default", "OAuth 2.0 audience expected in tokens")
+	)
+	fs.Parse(os.Args[1:])
+
 	// Context to control startup timeout.
 	ctx, cancel := context.WithTimeout(context.Background(), *startupTime)
 	defer cancel()
 
 	// Connect to MongoDB.
-	conn, err := connectDB(ctx)
+	mc, err := connectDB(ctx, *mongoURI)
 	if err != nil {
 		logrus.WithError(err).Error("failed to connect to database")
 		return
 	}
 	defer func() {
 		logrus.Info("disconnecting from database")
-		if err := conn.Disconnect(context.Background()); err != nil {
+		if err := mc.Disconnect(context.Background()); err != nil {
 			logrus.WithError(err).Warning("failed to disconnect from database")
 		}
 	}()
 
 	// Connect to NATS.
-	nc, err := connectNATS(ctx)
+	nc, err := connectNATS(ctx, *natsURIs)
 	if err != nil {
 		logrus.WithError(err).Error("failed to connect to messaging system")
 		return
@@ -153,7 +153,7 @@ func main() {
 		nc.Close()
 	}()
 
-	rc, err := connectRedis()
+	rc, err := connectRedis(*redisURI)
 	if err != nil {
 		logrus.WithError(err).Error("failed to connect to key value store")
 		return
@@ -181,13 +181,13 @@ func main() {
 	c := server.Config{
 		Version:            version,
 		HTTPAddr:           *httpAddr,
-		CORSAllowedOrigins: strings.Split(*corsAllowedOrigins, ","),
+		CORSAllowedOrigins: *corsAllowedOrigins,
 		CORSDebug:          *corsDebug,
-		Persist:            conn,
-		NATSConn:           nc,
-		RedisConn:          rc,
 		OAuth2IssuerURI:    *oauth2IssuerURI,
 		OAuth2Audience:     *oauth2Audience,
+		Persist:            mc,
+		NATSConn:           nc,
+		RedisConn:          rc,
 	}
 	s, err := server.New(ctx, c)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/prometheus/client_golang v1.4.1
 	github.com/rs/cors v1.7.0
 	github.com/sirupsen/logrus v1.4.2
+	github.com/spf13/pflag v1.0.5
 	github.com/tidwall/pretty v1.0.1 // indirect
 	github.com/xdg/stringprep v1.0.0 // indirect
 	go.mongodb.org/mongo-driver v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,7 @@ github.com/onsi/gomega v1.9.0 h1:R1uwffexN6Pr340GtYRIdZmAiN4J+iw6WG4wog1DUXg=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/pelletier/go-toml v1.4.0 h1:u3Z1r+oOXJIkxqw34zVhyPgjBsm6X2wn21NWs/HfSeg=
 github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
@@ -153,6 +154,8 @@ github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=


### PR DESCRIPTION
As a first step towards using [viper](https://github.com/spf13/viper) for configuration, switch from the `flag` package to [pflag](https://github.com/spf13/pflag). The `viper` package can bind in `pflag`s directly ([ref](https://github.com/spf13/viper#working-with-flags)).

Move use of the flagset into `main()`, to isolate usage of the values to that function. When `viper` is introduced, it will change the mechanism used to retrieve values, so this should simplify that transition.