### PR TITLE
Wire Up Services in Helm Chart

### DIFF
--- a/deployments/helm/fuzzball/templates/_helpers.tpl
+++ b/deployments/helm/fuzzball/templates/_helpers.tpl
@@ -61,3 +61,24 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the MongoDB URI to use
+*/}}
+{{- define "fuzzball.mongoURI" -}}
+mongodb://{{ .Values.mongodb.mongodbUsername }}:{{ .Values.mongodb.mongodbPassword }}@{{ .Release.Name }}-mongodb/{{ .Values.mongodb.mongodbDatabase }}
+{{- end -}}
+
+{{/*
+Create the NATS URI to use
+*/}}
+{{- define "fuzzball.natsURI" -}}
+nats://{{ .Values.nats.auth.user }}:{{ .Values.nats.auth.password }}@{{ .Release.Name }}-nats-client
+{{- end -}}
+
+{{/*
+Create the Redis URI to use
+*/}}
+{{- define "fuzzball.redisURI" -}}
+redis://:{{ .Values.redis.password }}@{{ .Release.Name }}-redis-master
+{{- end -}}

--- a/deployments/helm/fuzzball/templates/deployment.yaml
+++ b/deployments/helm/fuzzball/templates/deployment.yaml
@@ -27,6 +27,13 @@ spec:
           {{- toYaml .Values.securityContext | nindent 12 }}
         image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        - name: MONGO_URI
+          value: {{ include "fuzzball.mongoURI" . }}
+        - name: NATS_URIS
+          value: {{ include "fuzzball.natsURI" . }}
+        - name: REDIS_URI
+          value: {{ include "fuzzball.redisURI" . }}
         ports:
         - name: http
           containerPort: 8080

--- a/deployments/helm/fuzzball/values.yaml
+++ b/deployments/helm/fuzzball/values.yaml
@@ -62,8 +62,18 @@ affinity: {}
 mongodb:
   enabled: true
 
+  mongodbUsername: "changeme"
+  mongodbPassword: "changeme"
+  mongodbDatabase: "server"
+
 nats:
   enabled: true
 
+  auth:
+    user: "server"
+    password: "changeme"
+
 redis:
   enabled: true
+
+  password: "changeme"


### PR DESCRIPTION
Wire up MongoDB, NATS and Redis URIs in the `server` Helm chart.