### PR TITLE
Workaround for EKS Semver Issue

### DIFF
--- a/deployments/helm/fuzzball/Chart.yaml
+++ b/deployments/helm/fuzzball/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fuzzball
 version: 0.1.0
 appVersion: 0.1.0
-kubeVersion: ^1.14.0
+kubeVersion: ^1.14.0-0
 description: Programmatic management of high performance compute resources.
 type: application
 sources:


### PR DESCRIPTION
When attempting to deploy the Helm chart on [Amazon EKS](https://aws.amazon.com/eks/), the following error is observed:

```
Error: chart requires kubeVersion: ^1.14.0 which is incompatible with Kubernetes v1.14.9-eks-502bfb
```

Our Helm chart currently specifies a `kubeVersion` >= 1.14.0 here:

https://github.com/sylabs/compute-service/blob/fca8fdff9f5ef316ada3bce2be5ff1c2c8c12c64/deployments/helm/fuzzball/Chart.yaml#L5

The issue is that semantically, the AWS version of `v1.14.9-eks-502bfb` is a _pre-release_ version according to [semver 2.0.0 § 6](https://semver.org/#spec-item-9). This does not satisfy the version spec `^1.14.0`.

Using the suggestion found in https://github.com/helm/helm/issues/3810 to address this.