### PR TITLE
Helm: allow overriding image tag

### DIFF
--- a/deployments/helm/fuzzball/templates/deployment.yaml
+++ b/deployments/helm/fuzzball/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{ $imageTag := or ($.Values.image.tag) (.Chart.AppVersion) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -25,7 +26,7 @@ spec:
       - name: {{ .Chart.Name }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 12 }}
-        image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+        image: "{{ .Values.image.repository }}:{{ $imageTag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: MONGO_URI


### PR DESCRIPTION
Allow overriding the image tag (for example, to use `latest` in a local repo) while retaining the app version as the default version.