### PR TITLE
GraphQL: OAuth 2.0 parameter discovery

### DIFF
--- a/api/graphql-schema/oauth2Config.graphql
+++ b/api/graphql-schema/oauth2Config.graphql
@@ -1,0 +1,42 @@
+"""
+`OAuth2Configuration` represents OAuth 2.0 configuration.
+"""
+type OAuth2Configuration {
+    "Configuration for Authorization Code Flow with Proof Key for Code Exchange (if supported)."
+    authCodePkce: AuthCodePKCEConfig
+
+    "Configuration for Client Credentials Flow (if supported)."
+    clientCredentials: ClientCredentialsConfig
+}
+
+"""
+`AuthCodePKCEConfig` contains OAuth 2.0 configuration for the Authorization Code Flow with Proof
+Key for Code Exchange (PKCE).
+"""
+type AuthCodePKCEConfig {
+    "The client identifier to use."
+    clientId: String!
+
+    "The URL of the authorization server's authorization endpoint."
+    authorizationEndpoint: String!
+
+    "The URL of the authorization server's token endpoint."
+    tokenEndpoint: String!
+
+    "The URL of the redirect endpoint."
+    redirectEndpoint: String!
+
+    "Recommended scope(s) to request."
+    scopes: [String!]!
+}
+
+"""
+`ClientCredentialsConfig` contains OAuth 2.0 configuration for the Client Credentials Flow.
+"""
+type ClientCredentialsConfig {
+    "The URL of the authorization server's token endpoint."
+    tokenEndpoint: String!
+
+    "Recommended scope(s) to request."
+    scopes: [String!]!
+}

--- a/api/graphql-schema/query.graphql
+++ b/api/graphql-schema/query.graphql
@@ -2,6 +2,9 @@
 The query root of the GraphQL interface.
 """
 type Query {
+  "Get OAuth 2.0 configuration."
+  oauth2Config: OAuth2Configuration!
+
   "Build information about the server."
   serverBuildInfo(): BuildInfo!
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -288,11 +288,10 @@ func main() {
 		OAuth2Scopes:               cfg.GetStringSlice(keyOAuth2Scopes),
 		OAuth2PKCEClientID:         cfg.GetString(keyOAuth2PKCEClientID),
 		OAuth2PKCERedirectEndpoint: cfg.GetString(keyOAuth2PKCERedirectEndpoint),
-		Core:                       c,
 	}
 
 	// Spin up server.
-	s, err := server.New(ctx, sc)
+	s, err := server.New(ctx, c, sc)
 	if err != nil {
 		logrus.WithError(err).Error("failed to create server")
 		return

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -29,15 +29,18 @@ const (
 
 	dbName = "server"
 
-	keyStartupTime        = "startup-time"
-	keyHTTPAddr           = "http-addr"
-	keyCORSAllowedOrigins = "cors-allowed-origins"
-	keyCORSDebug          = "cors-debug"
-	keyMongoURI           = "mongo-uri"
-	keyNatsURIs           = "nats-uris"
-	keyRedisURI           = "redis-uri"
-	keyOAuth2IssuerURI    = "oauth2-issuer-uri"
-	keyOAuth2Audience     = "oauth2-audience"
+	keyStartupTime                = "startup-time"
+	keyHTTPAddr                   = "http-addr"
+	keyCORSAllowedOrigins         = "cors-allowed-origins"
+	keyCORSDebug                  = "cors-debug"
+	keyMongoURI                   = "mongo-uri"
+	keyNatsURIs                   = "nats-uris"
+	keyRedisURI                   = "redis-uri"
+	keyOAuth2IssuerURI            = "oauth2-issuer-uri"
+	keyOAuth2Audience             = "oauth2-audience"
+	keyOAuth2Scopes               = "oauth2-scopes"
+	keyOAuth2PKCEClientID         = "oauth2-pkce-client-id"
+	keyOAuth2PKCERedirectEndpoint = "oauth2-pkce-redirect-endpoint"
 )
 
 // Values set during build.
@@ -132,6 +135,9 @@ func getFlagSet() *pflag.FlagSet {
 	fs.String(keyRedisURI, "redis://localhost", "URI of Redis")
 	fs.String(keyOAuth2IssuerURI, "https://dev-930666.okta.com/oauth2/default", "URI of OAuth 2.0 issuer")
 	fs.String(keyOAuth2Audience, "api://default", "OAuth 2.0 audience expected in tokens")
+	fs.StringSlice(keyOAuth2Scopes, []string{"openid", "offline_access"}, "Recommended scope(s) for OAuth 2.0 clients to request")
+	fs.String(keyOAuth2PKCEClientID, "", "Client ID for OAuth 2.0 clients to use for Authorization Code flow with PKCE")
+	fs.String(keyOAuth2PKCERedirectEndpoint, "http://localhost:9876/authorization/callback", "Callback URL for OAuth 2.0 clients to use for Authorization Code flow with PKCE")
 
 	fs.Parse(os.Args[1:])
 
@@ -274,12 +280,15 @@ func main() {
 
 	// Set up server configuration.
 	sc := server.Config{
-		HTTPAddr:           cfg.GetString(keyHTTPAddr),
-		CORSAllowedOrigins: cfg.GetStringSlice(keyCORSAllowedOrigins),
-		CORSDebug:          cfg.GetBool(keyCORSDebug),
-		OAuth2IssuerURI:    cfg.GetString(keyOAuth2IssuerURI),
-		OAuth2Audience:     cfg.GetString(keyOAuth2Audience),
-		Core:               c,
+		HTTPAddr:                   cfg.GetString(keyHTTPAddr),
+		CORSAllowedOrigins:         cfg.GetStringSlice(keyCORSAllowedOrigins),
+		CORSDebug:                  cfg.GetBool(keyCORSDebug),
+		OAuth2IssuerURI:            cfg.GetString(keyOAuth2IssuerURI),
+		OAuth2Audience:             cfg.GetString(keyOAuth2Audience),
+		OAuth2Scopes:               cfg.GetStringSlice(keyOAuth2Scopes),
+		OAuth2PKCEClientID:         cfg.GetString(keyOAuth2PKCEClientID),
+		OAuth2PKCERedirectEndpoint: cfg.GetString(keyOAuth2PKCERedirectEndpoint),
+		Core:                       c,
 	}
 
 	// Spin up server.

--- a/internal/app/server/oauth_metadata.go
+++ b/internal/app/server/oauth_metadata.go
@@ -84,7 +84,7 @@ func getAuthMetadata(ctx context.Context, hc *http.Client, uri string) (md core.
 		if err != nil {
 			log.WithError(err).Warn("failed to get auth metadata")
 		} else {
-			log.WithField("metadata", fmt.Sprintf("%#v", md)).Info("got auth metadata")
+			log.WithField("metadata", fmt.Sprintf("%+v", md)).Info("got auth metadata")
 		}
 	}(time.Now())
 

--- a/internal/app/server/router_test.go
+++ b/internal/app/server/router_test.go
@@ -22,9 +22,9 @@ var testRouteConfigs = []struct {
 	path         string
 	expectedCode int
 }{
-	{"GetMetrics", http.MethodGet, "/metrics", http.StatusUnauthorized},
-	{"PostGraphQL", http.MethodPost, "/graphql", http.StatusUnauthorized},
-	{"GetGraphiQL", http.MethodGet, "/graphiql", http.StatusUnauthorized},
+	{"GetMetrics", http.MethodGet, "/metrics", http.StatusOK},
+	{"PostGraphQL", http.MethodPost, "/graphql", http.StatusBadRequest},
+	{"GetGraphiQL", http.MethodGet, "/graphiql", http.StatusOK},
 }
 
 func TestRouteConfigs(t *testing.T) {

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -21,7 +21,6 @@ type Config struct {
 	HTTPAddr                   string
 	CORSAllowedOrigins         []string
 	CORSDebug                  bool
-	Core                       *core.Core
 	OAuth2IssuerURI            string
 	OAuth2Audience             string
 	OAuth2Scopes               []string
@@ -34,20 +33,20 @@ type Server struct {
 	httpSrv  *http.Server
 	httpLn   net.Listener
 	schema   *graphql.Schema
-	authMeta core.AuthMetadata
 	authKeys jose.JSONWebKeySet
 }
 
 // New returns a new Server.
-func New(ctx context.Context, c Config) (s Server, err error) {
+func New(ctx context.Context, c *core.Core, cfg Config) (s Server, err error) {
+	logrus.WithField("config", fmt.Sprintf("%+v", cfg)).Info("server configuration")
+
 	hc := &http.Client{}
 
 	// Discover OAuth 2.0 metadata.
-	md, err := discoverAuthMetadata(ctx, hc, c.OAuth2IssuerURI)
+	md, err := discoverAuthMetadata(ctx, hc, cfg.OAuth2IssuerURI)
 	if err != nil {
 		return Server{}, err
 	}
-	s.authMeta = md
 
 	// Get OAuth key set.
 	ks, err := getKeySet(ctx, hc, md.JWKSURI)
@@ -60,26 +59,26 @@ func New(ctx context.Context, c Config) (s Server, err error) {
 	oc := resolver.OAuth2Configuration{
 		ClientCredentials: &resolver.ClientCredentialsConfig{
 			TokenEndpoint: md.TokenEndpoint,
-			Scopes:        c.OAuth2Scopes,
+			Scopes:        cfg.OAuth2Scopes,
 		},
 	}
-	if c.OAuth2PKCEClientID != "" && c.OAuth2PKCERedirectEndpoint != "" {
+	if cfg.OAuth2PKCEClientID != "" && cfg.OAuth2PKCERedirectEndpoint != "" {
 		oc.AuthCodePKCE = &resolver.AuthCodePKCEConfig{
-			ClientID:              c.OAuth2PKCEClientID,
+			ClientID:              cfg.OAuth2PKCEClientID,
 			AuthorizationEndpoint: md.AuthorizationEndpoint,
 			TokenEndpoint:         md.TokenEndpoint,
-			RedirectEndpoint:      c.OAuth2PKCERedirectEndpoint,
-			Scopes:                c.OAuth2Scopes,
+			RedirectEndpoint:      cfg.OAuth2PKCERedirectEndpoint,
+			Scopes:                cfg.OAuth2Scopes,
 		}
 	} else {
 		logrus.WithFields(logrus.Fields{
-			"ClientID":         c.OAuth2PKCEClientID,
-			"RedirectEndpoint": c.OAuth2PKCERedirectEndpoint,
+			"ClientID":         cfg.OAuth2PKCEClientID,
+			"RedirectEndpoint": cfg.OAuth2PKCERedirectEndpoint,
 		}).Warn("OAuth 2.0 Auth Code with PKCE disabled due to missing configuration value(s)")
 	}
 
 	// Initialize GraphQL.
-	r, err := resolver.New(c.Core, oc)
+	r, err := resolver.New(c, oc)
 	if err != nil {
 		return Server{}, err
 	}
@@ -90,7 +89,7 @@ func New(ctx context.Context, c Config) (s Server, err error) {
 	s.schema = schema
 
 	// Set up HTTP server.
-	h, err := s.NewRouter(c)
+	h, err := s.NewRouter(cfg)
 	if err != nil {
 		return Server{}, err
 	}
@@ -99,7 +98,7 @@ func New(ctx context.Context, c Config) (s Server, err error) {
 	}
 
 	// Start listening for HTTP.
-	ln, err := net.Listen("tcp", c.HTTPAddr)
+	ln, err := net.Listen("tcp", cfg.HTTPAddr)
 	if err != nil {
 		return Server{}, err
 	}

--- a/internal/app/server/server_test.go
+++ b/internal/app/server/server_test.go
@@ -33,7 +33,7 @@ func TestNewRunStop(t *testing.T) {
 		HTTPAddr:        "localhost:",
 		OAuth2IssuerURI: mds.URL,
 	}
-	s, err := New(ctx, c)
+	s, err := New(ctx, nil, c)
 	if err != nil {
 		t.Fatalf("failed to get new server: %v", err)
 	}

--- a/internal/pkg/core/build_info.go
+++ b/internal/pkg/core/build_info.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/blang/semver"
+	"github.com/sylabs/fuzzball-service/internal/pkg/token"
 )
 
 // BuildInfo contains build information about the core.
@@ -22,5 +23,8 @@ type BuildInfo struct {
 
 // GetBuildInfo returns build information about the core.
 func (c *Core) GetBuildInfo(ctx context.Context) (BuildInfo, error) {
+	if _, ok := token.FromContext(ctx); !ok {
+		return BuildInfo{}, ErrNotAuthenticated
+	}
 	return c.bi, nil
 }

--- a/internal/pkg/resolver/build_info_test.go
+++ b/internal/pkg/resolver/build_info_test.go
@@ -3,7 +3,6 @@
 package resolver
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -118,7 +117,7 @@ func TestBuildInfo(t *testing.T) {
 			  }
 			}`
 
-			res := s.Exec(context.Background(), q, "", nil)
+			res := s.Exec(getTokenContext(), q, "", nil)
 
 			if err := verifyGoldenJSON(t.Name(), res); err != nil {
 				t.Fatal(err)

--- a/internal/pkg/resolver/oauth2_config_query.go
+++ b/internal/pkg/resolver/oauth2_config_query.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2020, Sylabs, Inc. All rights reserved.
+
+package resolver
+
+// OAuth2Configuration represents OAuth 2.0 configuration.
+type OAuth2Configuration struct {
+	AuthCodePKCE      *AuthCodePKCEConfig      // Configuration for Authorization Code Flow with Proof Key for Code Exchange (if supported).
+	ClientCredentials *ClientCredentialsConfig // Configuration for Client Credentials Flow (if supported).
+}
+
+// AuthCodePKCEConfig contains OAuth 2.0 configuration for the Authorization Code Flow with Proof
+// Key for Code Exchange (PKCE).
+type AuthCodePKCEConfig struct {
+	ClientID              string   // The client identifier to use.
+	AuthorizationEndpoint string   // The URL of the authorization endpoint.
+	TokenEndpoint         string   // The URL of the token endpoint.
+	RedirectEndpoint      string   // The URL of the redirect endpoint.
+	Scopes                []string // Recommended scope(s) to request.
+}
+
+// ClientCredentialsConfig contains OAuth 2.0 configuration for the Client Credentials Flow.
+type ClientCredentialsConfig struct {
+	TokenEndpoint string   // The URL of the token endpoint.
+	Scopes        []string // Recommended scope(s) to request.
+}
+
+// OAuth2Config returns OAuth 2.0 configuration.
+func (r Resolver) OAuth2Config() OAuth2Configuration {
+	return r.c
+}

--- a/internal/pkg/resolver/resolver.go
+++ b/internal/pkg/resolver/resolver.go
@@ -12,9 +12,10 @@ type Servicer interface {
 // Resolver is the root type for resolving GraphQL queries.
 type Resolver struct {
 	s Servicer
+	c OAuth2Configuration
 }
 
 // New creates a new GraphQL resolver.
-func New(s Servicer) (*Resolver, error) {
-	return &Resolver{s: s}, nil
+func New(s Servicer, c OAuth2Configuration) (*Resolver, error) {
+	return &Resolver{s: s, c: c}, nil
 }

--- a/internal/pkg/resolver/resolver_test.go
+++ b/internal/pkg/resolver/resolver_test.go
@@ -70,7 +70,7 @@ func TestNew(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := New(mc); err != nil {
+	if _, err := New(mc, OAuth2Configuration{}); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/pkg/resolver/resolver_test.go
+++ b/internal/pkg/resolver/resolver_test.go
@@ -4,6 +4,7 @@ package resolver
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -12,6 +13,9 @@ import (
 	"path"
 	"strings"
 	"testing"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/sylabs/fuzzball-service/internal/pkg/token"
 )
 
 var update = flag.Bool("update", false, "update .golden files")
@@ -57,6 +61,20 @@ func verifyGoldenJSON(name string, v interface{}) error {
 	}
 
 	return verifyGolden(name, b)
+}
+
+// getTokenContext returns a context containing a valid token.
+func getTokenContext() context.Context {
+	// User token to pass in context.
+	tok := token.Token{
+		Token: jwt.NewWithClaims(jwt.SigningMethodNone, &token.Claims{
+			StandardClaims: jwt.StandardClaims{
+				Subject: "jimbob",
+			},
+			UserID: "507f1f77bcf86cd799439011",
+		}),
+	}
+	return token.NewContext(context.Background(), &tok)
 }
 
 func TestMain(m *testing.M) {

--- a/internal/pkg/resolver/viewer_test.go
+++ b/internal/pkg/resolver/viewer_test.go
@@ -3,26 +3,14 @@
 package resolver
 
 import (
-	"context"
 	"testing"
 
-	"github.com/dgrijalva/jwt-go"
 	"github.com/sylabs/fuzzball-service/internal/pkg/core"
 	"github.com/sylabs/fuzzball-service/internal/pkg/schema"
-	"github.com/sylabs/fuzzball-service/internal/pkg/token"
 )
 
 func TestViewerWorkflows(t *testing.T) {
-	// User token to pass in context.
-	tok := token.Token{
-		Token: jwt.NewWithClaims(jwt.SigningMethodNone, &token.Claims{
-			StandardClaims: jwt.StandardClaims{
-				Subject: "jimbob",
-			},
-			UserID: "507f1f77bcf86cd799439011",
-		}),
-	}
-	ctx := token.NewContext(context.Background(), &tok)
+	ctx := getTokenContext()
 
 	sc := "startCursor"
 	ec := "endCursor"
@@ -111,16 +99,7 @@ func TestViewerWorkflows(t *testing.T) {
 }
 
 func TestViewerJobs(t *testing.T) {
-	// User token to pass in context.
-	tok := token.Token{
-		Token: jwt.NewWithClaims(jwt.SigningMethodNone, &token.Claims{
-			StandardClaims: jwt.StandardClaims{
-				Subject: "jimbob",
-			},
-			UserID: "507f1f77bcf86cd799439011",
-		}),
-	}
-	ctx := token.NewContext(context.Background(), &tok)
+	ctx := getTokenContext()
 
 	sc := "startCursor"
 	ec := "endCursor"
@@ -209,16 +188,7 @@ func TestViewerJobs(t *testing.T) {
 }
 
 func TestViewerVolumes(t *testing.T) {
-	// User token to pass in context.
-	tok := token.Token{
-		Token: jwt.NewWithClaims(jwt.SigningMethodNone, &token.Claims{
-			StandardClaims: jwt.StandardClaims{
-				Subject: "jimbob",
-			},
-			UserID: "507f1f77bcf86cd799439011",
-		}),
-	}
-	ctx := token.NewContext(context.Background(), &tok)
+	ctx := getTokenContext()
 
 	sc := "startCursor"
 	ec := "endCursor"

--- a/internal/pkg/resolver/workflow_test.go
+++ b/internal/pkg/resolver/workflow_test.go
@@ -3,7 +3,6 @@
 package resolver
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -112,7 +111,7 @@ func TestWorkflowJobs(t *testing.T) {
 			  }
 			}`
 
-			res := s.Exec(context.Background(), q, "", tt.args)
+			res := s.Exec(getTokenContext(), q, "", tt.args)
 
 			if err := verifyGoldenJSON(t.Name(), res); err != nil {
 				t.Fatal(err)
@@ -222,7 +221,7 @@ func TestWorkflowVolumes(t *testing.T) {
 			  }
 			}`
 
-			res := s.Exec(context.Background(), q, "", tt.args)
+			res := s.Exec(getTokenContext(), q, "", tt.args)
 
 			if err := verifyGoldenJSON(t.Name(), res); err != nil {
 				t.Fatal(err)
@@ -304,7 +303,7 @@ func TestCreateWorkflow(t *testing.T) {
 			  }
 			}`
 
-			res := s.Exec(context.Background(), q, "", tt.vars)
+			res := s.Exec(getTokenContext(), q, "", tt.vars)
 			if err := verifyGoldenJSON(t.Name(), res); err != nil {
 				t.Fatal(err)
 			}
@@ -372,7 +371,7 @@ func TestDeleteWorkflow(t *testing.T) {
 				"id": tt.id,
 			}
 
-			res := s.Exec(context.Background(), q, "", args)
+			res := s.Exec(getTokenContext(), q, "", args)
 
 			if err := verifyGoldenJSON(t.Name(), res); err != nil {
 				t.Fatal(err)

--- a/internal/pkg/schema/schema.go
+++ b/internal/pkg/schema/schema.go
@@ -14,5 +14,5 @@ func Get(resolver interface{}) (*graphql.Schema, error) {
 	if err != nil {
 		return nil, err
 	}
-	return graphql.ParseSchema(s, resolver, graphql.UseStringDescriptions())
+	return graphql.ParseSchema(s, resolver, graphql.UseStringDescriptions(), graphql.UseFieldResolvers())
 }

--- a/internal/pkg/token/middleware.go
+++ b/internal/pkg/token/middleware.go
@@ -70,13 +70,16 @@ func parseAndValidate(tokenString string, kf jwt.Keyfunc) (*Token, error) {
 	return &Token{t}, nil
 }
 
-// verifyJWT attempts to extract a bearer token from the authorization header of r. If a valid
-// token is found, it is added to r.Context().
+// verifyJWT attempts to extract a bearer token from the authorization header of r.
+//
+// If a valid token is found, it is added to r.Context(). If no bearer token is present in r, this
+// is not considered to be an error. If a bearer token is present but cannot be parsed/validated,
+// an appropriate error is returned.
 func (m *Middleware) verifyJWT(r *http.Request) error {
 	// Get token from authorization header.
 	tokenString, err := getBearerToken(r)
 	if err != nil {
-		return err
+		return nil
 	}
 
 	// Parse the token.

--- a/internal/pkg/token/middleware_test.go
+++ b/internal/pkg/token/middleware_test.go
@@ -34,7 +34,11 @@ func TestHandler(t *testing.T) {
 					return testSigningKey, nil
 				},
 			})
-			h := m.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+			h := m.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if _, ok := FromContext(r.Context()); !ok {
+					w.WriteHeader(http.StatusUnauthorized)
+				}
+			}))
 
 			r := httptest.NewRequest(http.MethodGet, "/", nil)
 			if tt.token != "" {
@@ -93,7 +97,7 @@ func TestVerifyJWT(t *testing.T) {
 		{"InvalidAudience", testTokenInvalidAudience, true},
 		{"InvalidIssuer", testTokenInvalidIssuer, true},
 		{"Expired", testTokenExpired, true},
-		{"NoAuthHeader", "", true},
+		{"NoAuthHeader", "", false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Add `oauth2Config` GraphQL query, which allows unauthenticated discovery of OAuth 2.0 parameters.